### PR TITLE
chore: update domain to io.github.ccxxxi

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.github.ccxxxi.ecnu_timetable"
+        applicationId "io.github.ccxxxi.ecnu_timetable"
         minSdkVersion 16
         targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.ccxxxi.ecnu_timetable">
+          package="io.github.ccxxxi.ecnu_timetable">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,23 +1,23 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.ccxxxi.ecnu_timetable">
-   <application
-        android:label="ecnu_timetable"
-        android:icon="@mipmap/ic_launcher">
+          package="io.github.ccxxxi.ecnu_timetable">
+    <application
+            android:label="ecnu_timetable"
+            android:icon="@mipmap/ic_launcher">
         <activity
-            android:name=".MainActivity"
-            android:launchMode="singleTop"
-            android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
-            android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+                android:name=".MainActivity"
+                android:launchMode="singleTop"
+                android:theme="@style/LaunchTheme"
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+                android:hardwareAccelerated="true"
+                android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                    android:name="io.flutter.embedding.android.NormalTheme"
+                    android:resource="@style/NormalTheme"
+            />
             <!-- Displays an Android View that continues showing the launch screen
                  Drawable until Flutter paints its first frame, then this splash
                  screen fades out. A splash screen is useful to avoid any visual

--- a/android/app/src/main/kotlin/com/github/ccxxxi/ecnu_timetable/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/github/ccxxxi/ecnu_timetable/MainActivity.kt
@@ -1,6 +1,0 @@
-package com.github.ccxxxi.ecnu_timetable
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity() {
-}

--- a/android/app/src/main/kotlin/io/github/ccxxxi/ecnu_timetable/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/github/ccxxxi/ecnu_timetable/MainActivity.kt
@@ -1,0 +1,6 @@
+package io.github.ccxxxi.ecnu_timetable
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity() {
+}

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.ccxxxi.ecnu_timetable">
+          package="io.github.ccxxxi.ecnu_timetable">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -291,7 +291,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.github.ccxxxi.ecnuTimetable;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.ccxxxi.ecnuTimetable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -415,7 +415,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.github.ccxxxi.ecnuTimetable;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.ccxxxi.ecnuTimetable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -434,7 +434,7 @@
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.github.ccxxxi.ecnuTimetable;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.ccxxxi.ecnuTimetable;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 project(runner LANGUAGES CXX)
 
 set(BINARY_NAME "ecnu_timetable")
-set(APPLICATION_ID "com.github.ccxxxi.ecnu_timetable")
+set(APPLICATION_ID "io.github.ccxxxi.ecnu_timetable")
 
 cmake_policy(SET CMP0063 NEW)
 

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = ecnu_timetable
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.github.ccxxxi.ecnuTimetable
+PRODUCT_BUNDLE_IDENTIFIER = io.github.ccxxxi.ecnuTimetable
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2021 com.github.ccxxxi. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2021 io.github.ccxxxi. All rights reserved.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.github.ccxxxi" "\0"
+            VALUE "CompanyName", "io.github.ccxxxi" "\0"
             VALUE "FileDescription", "更美观更智能的ECNU课程表。" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "ecnu_timetable" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2021 com.github.ccxxxi. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2021 io.github.ccxxxi. All rights reserved." "\0"
             VALUE "OriginalFilename", "ecnu_timetable.exe" "\0"
             VALUE "ProductName", "ecnu_timetable" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
Subdomains of github.com are deprecated for GitHub Pages. They will not
redirect to github.io after April 15, 2021.